### PR TITLE
upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-axum = "0.7.3"
-base64 = "0.21.5"
-rand = "0.8.5"
-thiserror = "1.0.40"
-tower-cookies = "0.10.0"
-tower-layer = "0.3.2"
-tower-service = "0.3.2"
-tower-sessions = "0.9.1"
-tracing = "0.1.40"
+axum = "0.8.1"
+base64 = "0.22.1"
+rand = "0.9.0"
+thiserror = "2.0.12"
+tower-cookies = "0.11.0"
+tower-layer = "0.3.3"
+tower-service = "0.3.3"
+tower-sessions = "0.14.0"
+tracing = "0.1.41"
 
 [dev-dependencies]
-tokio = { version = "1.27.0", features = ["macros", "rt", "rt-multi-thread"] }
-tokio-test = "0.4.2"
-tower = "0.4.13"
-tower-http = { version = "0.5.0", features = ["cors"] }
+tokio = { version = "1.44.1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio-test = "0.4.4"
+tower = "0.5.2"
+tower-http = { version = "0.6.2", features = ["cors"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,18 +16,18 @@ edition = "2021"
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-axum = "0.8.1"
+axum = "0.8.9"
 base64 = "0.22.1"
-rand = "0.9.0"
-thiserror = "2.0.12"
+rand = "0.10.1"
+thiserror = "2.0.18"
 tower-cookies = "0.11.0"
 tower-layer = "0.3.3"
 tower-service = "0.3.3"
-tower-sessions = "0.14.0"
-tracing = "0.1.41"
+tower-sessions = "0.15.0"
+tracing = "0.1.44"
 
 [dev-dependencies]
-tokio = { version = "1.44.1", features = ["macros", "rt", "rt-multi-thread"] }
-tokio-test = "0.4.4"
-tower = "0.5.2"
-tower-http = { version = "0.6.2", features = ["cors"] }
+tokio = { version = "1.52.3", features = ["macros", "rt", "rt-multi-thread"] }
+tokio-test = "0.4.5"
+tower = "0.5.3"
+tower-http = { version = "0.6.11", features = ["cors"] }

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This middleware implements token transfer via [custom request headers](https://c
 
 The middleware requires and is built upon [`tower_sessions`](https://docs.rs/tower-sessions/).
 
-The current version is built for and works with `axum 0.7.x`, `tower-sessions 0.9.x`.
+The current version is built for and works with `axum 0.8.x`, `tower-sessions 0.14.x`.
 
 The [Same Origin Policy](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy) prevents the custom request header to be set by foreign scripts.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use base64::prelude::*;
-use rand::RngCore;
+use rand::TryRngCore;
 use tower_layer::Layer;
 use tower_sessions::Session;
 
@@ -316,7 +316,7 @@ impl CsrfLayer {
 
     async fn regenerate_token(&self, session: &Session) -> Result<String, Error> {
         let mut buf = [0; 32];
-        rand::thread_rng().try_fill_bytes(&mut buf)?;
+        let _: Result<(), Infallible> = rand::rng().try_fill_bytes(&mut buf);
         let token = BASE64_STANDARD.encode(buf);
         session.insert(self.session_key, &token).await?;
 
@@ -375,9 +375,6 @@ pub enum RegenerateToken {
 
 #[derive(thiserror::Error, Debug)]
 enum Error {
-    #[error("Random number generator error")]
-    Rng(#[from] rand::Error),
-
     #[error("Session error")]
     Session(#[from] tower_sessions::session::Error),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,7 +239,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use base64::prelude::*;
-use rand::TryRngCore;
+use rand::TryRng;
 use tower_layer::Layer;
 use tower_sessions::Session;
 


### PR DESCRIPTION
Dependency changes were made automatically with `cargo upgrade -i` in response to some warnings from `cargo audit`. This branch also removes the Rng variant of Error, as rand::thread_rng() is deprecated in favor of rand::rng(), whose return value is of type OsRng, which return Result<(), Infallible> when try_fill_bytes() is called on it.